### PR TITLE
Fixed broken image & pdf links throughout app

### DIFF
--- a/SchematicDesign/SchematicDesign.md
+++ b/SchematicDesign/SchematicDesign.md
@@ -7,7 +7,8 @@ This is a work in progress, it will be updated as we get feedback and ideas from
 
 #### The layout
 
-![Here](https://github.com/erich001/STEMMRoleModels/blob/master/conceptualdesign.pdf) is an image of how one would navigate the app. 
+How one would navigate the app
+![App nagivation](https://github.com/KirstieJane/STEMMRoleModels/raw/gh-pages/SchematicDesign/conceptualdesign.png)
 
 Main interface pages include:
    * Home
@@ -44,6 +45,4 @@ Here's where we need your help!
   
 ###### Other
   * What suggestions do you have? Let us know!
-
-  
 

--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
 
 <h2>Here's our plan</h2>
 
-<a href="https://github.com/KirstieJane/STEMMRoleModels/blob/master/SchematicDesign/conceptualdesign.pdf">
+<a href="https://raw.githubusercontent.com/KirstieJane/STEMMRoleModels/gh-pages/SchematicDesign/conceptualdesign.png">
  <img src="SchematicDesign/conceptualdesign.png" alt="Schematic Design">
 </a>
 

--- a/index.html
+++ b/index.html
@@ -78,6 +78,10 @@
  <img src="SchematicDesign/conceptualdesign.png" alt="Schematic Design">
 </a>
 
+<a href="https://github.com/KirstieJane/STEMMRoleModels/raw/gh-pages/SchematicDesign/conceptualdesign.pdf">
+ (download)
+</a>
+
 <p>You'll start at the home page and there will be three options:</p>
 
   <ol>

--- a/site/new_search.html
+++ b/site/new_search.html
@@ -34,8 +34,8 @@
 
       <p>This is the page at which you would enter your search terms</p>
 
-      <a href="https://github.com/KirstieJane/STEMMRoleModels/blob/master/SchematicDesign/conceptualdesign.pdf">
-       <img src="../SchematicDesign/new_search_design.png"
+      <a href="https://github.com/KirstieJane/STEMMRoleModels/raw/gh-pages/SchematicDesign/conceptualdesign.pdf">
+       <img src="https://github.com/KirstieJane/STEMMRoleModels/raw/gh-pages/SchematicDesign/conceptualdesign.png"
             alt="New search design"
             width="50%"
             style="float:right">

--- a/site/new_search.html
+++ b/site/new_search.html
@@ -35,7 +35,7 @@
       <p>This is the page at which you would enter your search terms</p>
 
       <a href="https://github.com/KirstieJane/STEMMRoleModels/raw/gh-pages/SchematicDesign/conceptualdesign.pdf">
-       <img src="https://github.com/KirstieJane/STEMMRoleModels/raw/gh-pages/SchematicDesign/conceptualdesign.png"
+       <img src="../SchematicDesign/new_search_design.png"
             alt="New search design"
             width="50%"
             style="float:right">


### PR DESCRIPTION
Fixes #51 
- [x] Fixed broken image links
- [x] Replaced broken PDF view on homepage to image view
- [x] Added PDF download for full diagram version to homepage next to image view

Click to view the image, displays larger image...
<img width="1224" alt="screenshot 2016-04-22 07 50 25" src="https://cloud.githubusercontent.com/assets/624760/14733964/e9abad5a-085e-11e6-8e8c-2fa3dd6e030a.png">

PDF Download link added...
<img width="741" alt="screenshot 2016-04-22 07 50 17" src="https://cloud.githubusercontent.com/assets/624760/14733970/fcfac652-085e-11e6-983d-68f31599c28e.png">
