### PR TITLE
Replaces references to master with gh-pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,16 +60,16 @@
   <a href="site/multimedia.html">multimedia</a> page.</p>
 
 <p>If you'd like to know more please take a look at our
-  <a href="https://github.com/KirstieJane/STEMMRoleModels/blob/master/README.md">README</a> file
+  <a href="https://github.com/KirstieJane/STEMMRoleModels/blob/gh-pages/README.md">README</a> file
   for an overview of the idea, where it came from and where we want to go with it,
-  our <a href="https://github.com/KirstieJane/STEMMRoleModels/blob/master/CONTRIBUTING.md">how to guide for contributors</a>,
+  our <a href="https://github.com/KirstieJane/STEMMRoleModels/blob/gh-pages/CONTRIBUTING.md">how to guide for contributors</a>,
   and our <a href="https://github.com/KirstieJane/STEMMRoleModels/issues">list of issues</a> that we need help with.</p>
 
 <h2>Meet the team</h2>
 
 <p>You can also learn a little more about Kirstie, Amy, Erin and Elizabeth
   - the founders of the STEMM Role Models app - in our
-  <a href="https://github.com/KirstieJane/STEMMRoleModels/blob/master/MeetTheTeam.md">meet the team</a> file</p>
+  <a href="https://github.com/KirstieJane/STEMMRoleModels/blob/gh-pages/MeetTheTeam.md">meet the team</a> file</p>
 
 <h2>Here's our plan</h2>
 
@@ -90,7 +90,7 @@
   </ol>
 
 <p>There will also be links on every page to the
-  <a href="https://github.com/KirstieJane/STEMMRoleModels/blob/master/CODE_OF_CONDUCT.md">code of conduct</a>,
+  <a href="https://github.com/KirstieJane/STEMMRoleModels/blob/gh-pages/CODE_OF_CONDUCT.md">code of conduct</a>,
   <a href="https://github.com/KirstieJane/STEMMRoleModels/issues/29">privacy policy</a> and
   <a href="https://github.com/KirstieJane/STEMMRoleModels#contact-us">how to contact us</a>.</p>
 


### PR DESCRIPTION
In the README, there are references to markdown blobs in the master branch of STEMMRoleModels. When clicking from the github pages page, GitHub is not forwarding the request to the file located in the gh-branch, and so the CONTRIBUTING, About the team, etc. show up as 404 not found.
